### PR TITLE
* require pathname to fix the agent - was throwing errors without that

### DIFF
--- a/lib/mcollective/agent/shell/job.rb
+++ b/lib/mcollective/agent/shell/job.rb
@@ -1,4 +1,5 @@
 require 'securerandom'
+require 'pathname'
 
 # The Job class manages the spawning and state tracking for a process as it's
 # running.


### PR DESCRIPTION
I needed this small change to make it work. My environment:

FreeBSD 10.0-RELEASE-p6
mcollective-2.5.1
ruby-1.9.3.484_2,1
