### PR TITLE
Fix to allow spaces in path to Ruby

### DIFF
--- a/lib/mcollective/agent/shell/job.rb
+++ b/lib/mcollective/agent/shell/job.rb
@@ -184,7 +184,7 @@ module MCollective
             'ruby',
           ]
 
-          found = candidates.find { |path| system('%s -e 42' % path) }
+          found = candidates.find { |path| system('"%s" -e 42' % path) }
 
           if found
             @@ruby = found


### PR DESCRIPTION
On windows you may have ruby installed under Program Files. The space was causing an issue finding ruby.exe.