### PR TITLE
Feature/ruby 187 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 bundler_args: --without development
 script: "bundle exec rake test SPEC_OPTS='--format documentation'"
 rvm:
+  - 1.8.7
   - 1.9.3
   - 2.0.0
 env:

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,11 @@
 #!ruby
 source 'https://rubygems.org'
 
+if RUBY_VERSION < '1.9.0'
+  gem 'posix-spawn'
+  gem 'uuid'
+end
+
 group :test do
   gem 'rake'
   gem 'rspec', '~> 2.11.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,6 @@
 #!ruby
 source 'https://rubygems.org'
 
-if RUBY_VERSION < '1.9.0'
-  gem 'posix-spawn'
-  gem 'uuid'
-end
-
 group :test do
   gem 'rake'
   gem 'rspec', '~> 2.11.0'
@@ -19,4 +14,10 @@ if mcollective_version
   gem 'mcollective-client', mcollective_version, :require => false
 else
   gem 'mcollective-client', :require => false
+end
+
+platforms :ruby_18 do
+  gem 'posix-spawn'
+  gem 'uuid'
+  gem 'i18n', ' ~> 0.6.0' if mcollective_version == '~> 2.4.0'
 end

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ the processes)
 To use this agent you need at least:
 
 * MCollective 2.2.4
-* Ruby 1.9 (for Process#spawn)
+* For Ruby 1.8.7 support: 'posix-spawn' and 'uuid' gem
 
 Please report any errors or make feature requests in the [MCOP jira project][MCOP]
 

--- a/lib/mcollective/agent/shell.rb
+++ b/lib/mcollective/agent/shell.rb
@@ -56,6 +56,11 @@ module MCollective
         reply[:stderr] = process.stderr
         reply[:exitcode] = process.exitcode
         process.cleanup_state
+        # This is only needed to emulate the behaviour of Process.spawn
+        # with POSIX::Spawn.spawn if the command was not found.
+        if reply[:exitcode] == 127
+          raise "No such file or directory - #{request[:command].scan(/\S+/)[0]}"
+        end
       end
 
       def start_command(request = {})

--- a/lib/mcollective/agent/shell/job.rb
+++ b/lib/mcollective/agent/shell/job.rb
@@ -1,5 +1,6 @@
 require 'securerandom'
 require 'pathname'
+require 'mcollective/agent/shell/job/backports' if RUBY_VERSION < '1.9.0'
 
 # The Job class manages the spawning and state tracking for a process as it's
 # running.
@@ -29,7 +30,7 @@ module MCollective
         def self.list
           jobs = []
           Dir.entries(state_path).each do |handle|
-            next if handle[0] == '.'
+            next if handle[0] == '.'[0]
             jobs << Job.new(handle)
           end
           return jobs
@@ -196,6 +197,8 @@ module MCollective
 
         def wrapper
           return <<-WRAPPER
+            #{File.read(File.join(File.dirname(__FILE__), 'job', 'backports.rb')) if RUBY_VERSION < '1.9.0'}
+
             command = IO.read("#{state_directory}/command").chomp
 
             options = {

--- a/lib/mcollective/agent/shell/job/backports.rb
+++ b/lib/mcollective/agent/shell/job/backports.rb
@@ -1,0 +1,15 @@
+require 'rubygems'
+require 'posix-spawn'
+require 'uuid'
+
+module Process
+  def self.spawn(*arguments)
+    ::POSIX::Spawn.spawn(*arguments)
+  end
+end
+
+module SecureRandom
+  def self.uuid
+    ::UUID.generate
+  end
+end

--- a/lib/mcollective/application/shell/prefix_stream_buf.rb
+++ b/lib/mcollective/application/shell/prefix_stream_buf.rb
@@ -19,7 +19,7 @@ module MCollective
           chunks = @buffer.lines.to_a
           return if chunks.empty?
 
-          if chunks[-1][-1] != "\n"
+          if chunks[-1][-1] != "\n"[0]
             @buffer = chunks[-1]
             chunks.pop
           else


### PR DESCRIPTION
Ruby 1.8.7 support.

This uses the 'posix-spawn' and 'uuid' library to get the functionality of Process.spawn and SecureRandom.uuid in ruby 1.8.7. There are also some other small fixes to make the plugin compatible to Ruby 1.8.7.

The gems are only required if you want to run the agent on 1.8.7 so it does not add dependencies for > 1.9.3 only users.